### PR TITLE
Link to gcc_s and gcc if compiler is GCC version 5

### DIFF
--- a/tensorflow/contrib/cmake/tf_python.cmake
+++ b/tensorflow/contrib/cmake/tf_python.cmake
@@ -582,6 +582,12 @@ add_library(pywrap_tensorflow_internal SHARED
     ${pywrap_tensorflow_deffile}
 )
 
+# There is a bug in GCC 5 resulting in undefined reference to a __cpu_model function when
+# linking to the tensorflow library. Adding the following libraries fixes it.
+if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
+    target_link_libraries(pywrap_tensorflow_internal PRIVATE gcc_s gcc)
+endif()
+
 if(WIN32)
     add_dependencies(pywrap_tensorflow_internal pywrap_tensorflow_internal_static)
 endif(WIN32)


### PR DESCRIPTION
When using cmake and GCC 5.4 to build tensorflow in Ubuntu 16.04,
the following error message would show up when loading
_pywrap_tensorflow_internal.so:
```
_pywrap_tensorflow_internal.so: undefined symbol: __cpu_model
```

The root cause is the same to this issue:
https://github.com/tensorflow/tensorflow/issues/9593

Signed-off-by: Yihong Wang <yh.wang@ibm.com>